### PR TITLE
making conformance score more robust

### DIFF
--- a/src/signature_mahalanobis_knn/sig_mahal_knn.py
+++ b/src/signature_mahalanobis_knn/sig_mahal_knn.py
@@ -181,6 +181,7 @@ class SignatureMahalanobisKNN:
         signatures_test: np.ndarray | None = None,
         n_neighbors: int = 20,
         return_indices: bool = False,
+        take_median: bool = False,
     ) -> np.ndarray:
         """
         Compute the conformance scores for the data points either passed in
@@ -202,9 +203,14 @@ class SignatureMahalanobisKNN:
         signatures_test : np.ndarray | None, optional
             Signatures of the data points, by default None.
             Two dimensional array of shape (n_samples, sig_dim).
+        n_neighbors : int, optional
         return_indices : bool, optional
             Whether to return the indices of the nearest neighbors,
             by default False.
+        take_median : bool, optional
+            Whether we should take the median distance of the k nearest neighbours.
+            By default, the pipeline takes the minimum distance. (min of k nearest neighbours = closest neighbour)
+            Setting take_median to true allows for a more robust measure.
 
         Returns
         -------
@@ -274,8 +280,16 @@ class SignatureMahalanobisKNN:
         candidate_distances[denominator < self.mahal_distance.zero_thres] = 0
         candidate_distances[rho > self.mahal_distance.subspace_thres] = np.inf
 
-        # compute the minimum of the candidate distances for each data point
-        if return_indices:
-            return np.min(candidate_distances, axis=-1), train_indices
+    
+        if take_median:
+            # compute the median of the k nearest neighbour distances for each data point for robustness
+            if return_indices:
+                return np.median(candidate_distances, axis=-1), train_indices
+            return np.median(candidate_distances, axis=-1)
+        
+        else:
+            # compute the minimum of the candidate distances for each data point = 1-nearest neighbour distance (the vanilla implementation)
+            if return_indices:
+                return np.min(candidate_distances, axis=-1), train_indices
 
-        return np.min(candidate_distances, axis=-1)
+            return np.min(candidate_distances, axis=-1)


### PR DESCRIPTION
added:
- k-NN to computation of score value (before, the score value computation was based on a 1-NN search and only the thresholding to 0 and infinity used all k neighbours)
- aggregation of the k-NN neighbours happens robustly using the median function

The previous implementation took for the computation of the score value the minimum of the k-nearest neighbours =  the 1-nearest neighbour, aka the parameter k had no influence except for the thresholding. This lead in some cases to anomalous behaviour if the corpus had some variance among itself.

The previous implementation could lead to such cases:
![Picture 1](https://github.com/datasig-ac-uk/signature_mahalanobis_knn/assets/20500098/b7256d9b-ac27-41b7-8f9f-458a2002e822)

Where, notably, the outliers are to the left of the inliers (inliers = generated from same distribution as the corpus). The dataset is here quiet complicated and we do not expect the algorithm to be able to distinguish between inliers and type-2-outliers; but at the very least, the type-2-outliers should not be closer to the corpus than the inliers (in fact, type-2-outliers are generated from a higher variance distribution than the corpus) . However, as evident in this first plot, the type-2-outliers are closer (lower conformance score) than the inliers.

Using the newly proposed median feature for k=10 nearest neighbours, this issue gets fixed:
![Picture 2](https://github.com/datasig-ac-uk/signature_mahalanobis_knn/assets/20500098/58866399-11c6-4604-a400-d5b42ef5d91b)

